### PR TITLE
handle missing request header

### DIFF
--- a/src/validators/actix.rs
+++ b/src/validators/actix.rs
@@ -67,9 +67,12 @@ pub async fn clerk_authorize(req: &ServiceRequest, clerk_client: &Clerk) -> Resu
         Err(_) => return Err(HttpResponse::InternalServerError().json("Error: Could not fetch JWKS!"))
     };
     // Parse the request headers
-    let access_token: &str = match req.headers().get("Authorization").unwrap().to_str() {
-        Ok(val) => val,
-        Err(_) => return Err(HttpResponse::InternalServerError().json("Error: No Authorization header found on the request payload!"))
+    let access_token: &str = match req.headers().get("Authorization") {
+        Some(val) => { match val.to_str() {
+            Ok(val) => val,
+            Err(_) => return Err(HttpResponse::BadRequest().json("Error: Unable to parse http header"))
+        }},
+        None => return Err(HttpResponse::BadRequest().json("Error: No Authorization header found on the request payload!"))
     };
 
     // Finally, check if the jwt is valid...


### PR DESCRIPTION
Return 4xx (client error) when the client is missing required data in the request, in this case it is the `Authorization` header. Also going out on a limb saying its a bad request (4xx series) if the server is unable to parse whatever data is that header. Previously, the `.unwrap()` on the Option would panic the actix-web server. This returns the 4xx response instead of crashing/panic.

I ran `cargo fmt` and got a bunch of changes, so left those out of the PR.