### PR TITLE
`sid` optional in Clerk JWT

### DIFF
--- a/src/validators/actix.rs
+++ b/src/validators/actix.rs
@@ -24,7 +24,7 @@ pub struct ClerkJwt {
 	pub iat: i32,
 	pub iss: String,
 	pub nbf: i32,
-	pub sid: String,
+	pub sid: Option<String>,
 	pub sub: String,
 }
 


### PR DESCRIPTION
Clerk doesn't return the sid by default when using a JWT Template. I don't know if this is a Clerk bug, or if its just not normally required. I posted in their support channel to see if I can figure it out.
https://discord.com/channels/856971667393609759/1100823061013463152/1100823061013463152